### PR TITLE
Generalize template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 ## Intentions
 
-- [ ] This is intended to be an app template starting point
-- [ ] It is intended to be used as a starting point for building a mobile app using Expo, Convex, and Clerk
+- [x] This is an app template starting point
+- [x] Use it as the foundation for building a mobile app with Expo, Convex, and Clerk
 
 ## TODO:
 
 - [ ] Add apple auth
-- [ ] Strip out specific components and make generic
+- [x] Strip out specific components and make generic
 - [ ] Add expo-updates
 - [ ] Add error handling, log drain, posthog
 - [ ] Update readme
 - [ ] Scope out next steps
 
-This is an [Expo](https://expo.dev) project integrated with [Convex](https://convex.dev) for the backend and [Clerk](https://clerk.com) for authentication.
+This template integrates [Expo](https://expo.dev) for the client, [Convex](https://convex.dev) for the backend, and [Clerk](https://clerk.com) for authentication.
 
 ## Get started
 
@@ -62,9 +62,9 @@ This is an [Expo](https://expo.dev) project integrated with [Convex](https://con
    pnpm start
    ```
 
-## Profile Features
+## Example Profile Features
 
-The app includes:
+The template includes example code for:
 
 - User profile display with Clerk authentication
 - Profile editing functionality (first name, last name, location, bio)

--- a/app.json
+++ b/app.json
@@ -1,11 +1,11 @@
 {
   "expo": {
-    "name": "soonlist",
-    "slug": "soonlist",
+    "name": "Expo Convex Clerk Template",
+    "slug": "expo-convex-clerk-template",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "soonlist",
+    "scheme": "expo-convex-clerk-template",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {

--- a/app/(auth)/intro.tsx
+++ b/app/(auth)/intro.tsx
@@ -48,8 +48,8 @@ export default function Intro() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.content}>
-        <Text style={styles.title}>SoonList</Text>
-        <Text style={styles.subtitle}>Track what you want to do soon</Text>
+        <Text style={styles.title}>Welcome</Text>
+        <Text style={styles.subtitle}>Sign in to get started</Text>
 
         <View style={styles.buttonContainer}>
           <TouchableOpacity

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "soonlist",
+  "name": "expo-convex-clerk-template",
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {


### PR DESCRIPTION
## Summary
- generalize intro screen and remove SoonList branding
- update project name to `expo-convex-clerk-template`
- document new generic purpose in README

## Testing
- `pnpm lint` *(fails: expo not found)*