### PR TITLE
Enable PostHog for web and macOS

### DIFF
--- a/components/Providers/index.tsx
+++ b/components/Providers/index.tsx
@@ -7,6 +7,8 @@ import ErrorBoundary from "react-native-error-boundary";
 import FallbackComponent from "react-native-error-boundary/lib/ErrorBoundary/FallbackComponent";
 import { PostHogProvider, usePostHog } from 'posthog-react-native';
 import { useEffect } from "react";
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
 import { useExpoUpdates } from "@/hooks/useExpoUpdates";
 
 // Custom token cache for Clerk
@@ -59,13 +61,20 @@ export default function RootProvider({ children }: Props): JSX.Element {
     throw new Error("Missing EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY");
   }
 
+  const posthogOptions: Record<string, unknown> = {
+    host: 'https://us.i.posthog.com',
+    enableSessionReplay: true,
+  };
+
+  if (Platform.OS === 'web' || Platform.OS === 'macos') {
+    posthogOptions.persistence = 'asyncStorage';
+    posthogOptions.storage = AsyncStorage;
+  }
+
   return (
     <PostHogProvider
       apiKey="phc_xFdnzXhdRoS2sHiQziB8NZvDZ3u9VCeJ44eEft1taA3"
-      options={{
-        host: 'https://us.i.posthog.com',
-        enableSessionReplay: true,
-      }}
+      options={posthogOptions}
       autocapture
     >
       <ClerkProvider publishableKey={clerkPublishableKey} tokenCache={tokenCache}>

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "expo-constants": "~17.1.6",
     "expo-device": "~7.1.4",
     "expo-file-system": "~18.1.10",
+    "@react-native-async-storage/async-storage": "^1.21.0",
     "expo-font": "~13.3.1",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.1.7",


### PR DESCRIPTION
## Summary
- configure PostHog to use AsyncStorage on web and macOS
- add `@react-native-async-storage/async-storage` dependency

## Testing
- `pnpm --version`