### PR TITLE
[expo-convex-clerk] clarify AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,3 @@
 # Contributor Guide
 
-Always consult the configuration rules in `.cursor/rules` before making changes. This repository contains a template Expo application that uses Convex for the backend and Clerk for authentication. Most application code lives in the following folders:
-
-- `app/` – Expo Router pages
-- `components/` – Reusable React components
-- `hooks/` – Custom React hooks
-- `constants/` – Miscellaneous constants
-- `convex/` – Convex backend functions and schema
-- `scripts/` – Maintenance scripts
-
-## Dev Environment Tips
-- Use **pnpm** for all package management tasks.
-- Install dependencies with `pnpm install`.
-- Start the Expo development server with `pnpm start`.
-
-## Testing Instructions
-This template does not include automated tests yet. Validate changes by running the linter:
-
-```bash
-pnpm lint
-```
-
-Ensure the command exits without errors before committing.
+Always consult the configuration rules in `.cursor/rules` before making changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Contributor Guide
+
+Always consult the configuration rules in `.cursor/rules` before making changes. This repository contains a template Expo application that uses Convex for the backend and Clerk for authentication. Most application code lives in the following folders:
+
+- `app/` – Expo Router pages
+- `components/` – Reusable React components
+- `hooks/` – Custom React hooks
+- `constants/` – Miscellaneous constants
+- `convex/` – Convex backend functions and schema
+- `scripts/` – Maintenance scripts
+
+## Dev Environment Tips
+- Use **pnpm** for all package management tasks.
+- Install dependencies with `pnpm install`.
+- Start the Expo development server with `pnpm start`.
+
+## Testing Instructions
+This template does not include automated tests yet. Validate changes by running the linter:
+
+```bash
+pnpm lint
+```
+
+Ensure the command exits without errors before committing.


### PR DESCRIPTION
## Summary
- remove PR instructions from contributor guide
- emphasize referencing `.cursor` rules

## Testing
- `pnpm lint` *(fails: node_modules missing)*