### PR TITLE
Enable query caching via convex-helpers

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,8 +1,4 @@
-import {
-  Authenticated,
-  Unauthenticated,
-  useConvexAuth,
-} from "convex/react";
+import { Authenticated, Unauthenticated, useConvexAuth } from "convex/react";
 import { useQuery } from "convex-helpers/react/cache";
 import { Redirect, Stack } from "expo-router";
 import React from "react";

--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -2,8 +2,8 @@ import {
   Authenticated,
   Unauthenticated,
   useConvexAuth,
-  useQuery,
 } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache";
 import { Redirect, Stack } from "expo-router";
 import React from "react";
 import { ActivityIndicator, StyleSheet, View } from "react-native";

--- a/app/(tabs)/profile-update.tsx
+++ b/app/(tabs)/profile-update.tsx
@@ -1,6 +1,7 @@
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache";
 import { Image } from "expo-image";
 import * as ImagePicker from "expo-image-picker";
 import { Stack, useRouter } from "expo-router";

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,7 +1,7 @@
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
 import { useAuth } from "@clerk/clerk-expo";
-import { useQuery } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache";
 import { Image } from "expo-image";
 import { Stack, useRouter } from "expo-router";
 import { usePostHog } from "posthog-react-native";

--- a/app/onboarding/bio.tsx
+++ b/app/onboarding/bio.tsx
@@ -1,4 +1,5 @@
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache";
 import { Stack, useRouter } from "expo-router";
 import { Controller, useForm } from "react-hook-form";
 import {

--- a/app/onboarding/first-name.tsx
+++ b/app/onboarding/first-name.tsx
@@ -1,4 +1,5 @@
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache";
 import { Stack, useRouter } from "expo-router";
 import { Controller, useForm } from "react-hook-form";
 import {

--- a/app/onboarding/last-name.tsx
+++ b/app/onboarding/last-name.tsx
@@ -1,4 +1,5 @@
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache";
 import { Stack, useRouter } from "expo-router";
 import { Controller, useForm } from "react-hook-form";
 import {

--- a/app/onboarding/location.tsx
+++ b/app/onboarding/location.tsx
@@ -1,4 +1,5 @@
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache";
 import { Stack, useRouter } from "expo-router";
 import { Controller, useForm } from "react-hook-form";
 import {

--- a/components/Providers/index.tsx
+++ b/components/Providers/index.tsx
@@ -5,6 +5,7 @@ import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { ConvexReactClient } from "convex/react";
 import { ConvexProviderWithClerk } from "convex/react-clerk";
+import { ConvexQueryCacheProvider } from "convex-helpers/react/cache";
 import * as SecureStore from "expo-secure-store";
 import { PostHogProvider, usePostHog } from "posthog-react-native";
 import { useEffect } from "react";
@@ -90,15 +91,17 @@ export default function RootProvider({ children }: Props): JSX.Element {
         <ClerkLoaded>
           {/* eslint-disable-next-line react-compiler/react-compiler */}
           <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
-            <ErrorBoundary
-              FallbackComponent={FallbackComponent}
-              onError={handleErrorConsole}
-            >
-              <PostHogIdentityTracker />
-              <BottomSheetModalProvider>
-                <ActionSheetProvider>{children}</ActionSheetProvider>
-              </BottomSheetModalProvider>
-            </ErrorBoundary>
+            <ConvexQueryCacheProvider>
+              <ErrorBoundary
+                FallbackComponent={FallbackComponent}
+                onError={handleErrorConsole}
+              >
+                <PostHogIdentityTracker />
+                <BottomSheetModalProvider>
+                  <ActionSheetProvider>{children}</ActionSheetProvider>
+                </BottomSheetModalProvider>
+              </ErrorBoundary>
+            </ConvexQueryCacheProvider>
           </ConvexProviderWithClerk>
         </ClerkLoaded>
       </ClerkProvider>

--- a/components/TaskItem.tsx
+++ b/components/TaskItem.tsx
@@ -3,7 +3,8 @@ import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
 import { WorkflowId } from "@convex-dev/workflow";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
+import { useQuery } from "convex-helpers/react/cache";
 import { useState } from "react";
 import {
   ActivityIndicator,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,24 @@ const expoConfig = require("eslint-config-expo/flat");
 const reactCompilerPlugin = require("eslint-plugin-react-compiler");
 const eslintPluginPrettierRecommended = require("eslint-plugin-prettier/recommended");
 
+const convexQueryImportsRule = {
+  rules: {
+    "no-restricted-imports": [
+      "warn",
+      {
+        paths: [
+          {
+            name: "convex/react",
+            importNames: ["useQuery", "useQueries"],
+            message:
+              "Import useQuery and useQueries from convex-helpers/react/cache instead of convex/react",
+          },
+        ],
+      },
+    ],
+  },
+};
+
 module.exports = defineConfig([
   expoConfig,
   eslintPluginPrettierRecommended,
@@ -15,6 +33,7 @@ module.exports = defineConfig([
       "react-compiler/react-compiler": "error", // or "warn"
     },
   },
+  convexQueryImportsRule,
   {
     ignores: ["dist/*"],
   },


### PR DESCRIPTION
## Summary
- wrap app providers with `ConvexQueryCacheProvider`
- use cache-enabled `useQuery` hooks everywhere

## Testing
- `pnpm lint` *(fails: expo not found, dependencies not installed)*