### PR TITLE
Synchronize NativeWind theme with system preference

### DIFF
--- a/hooks/useColorScheme.web.ts
+++ b/hooks/useColorScheme.web.ts
@@ -1,3 +1,4 @@
+import { useColorScheme as useNativewindColorScheme } from "nativewind";
 import { useEffect, useState } from "react";
 import { useColorScheme as useRNColorScheme } from "react-native";
 
@@ -6,16 +7,41 @@ import { useColorScheme as useRNColorScheme } from "react-native";
  */
 export function useColorScheme() {
   const [hasHydrated, setHasHydrated] = useState(false);
+  const { colorScheme, setColorScheme, toggleColorScheme } =
+    useNativewindColorScheme();
+  const systemColorScheme = useRNColorScheme();
 
   useEffect(() => {
     setHasHydrated(true);
   }, []);
 
-  const colorScheme = useRNColorScheme();
+  // Sync the NativeWind theme with the system setting
+  // Only depend on the system preference to avoid update loops
+  useEffect(() => {
+    if (
+      systemColorScheme &&
+      (!colorScheme || colorScheme !== systemColorScheme)
+    ) {
+      setColorScheme(systemColorScheme);
+    }
+    // intentionally omit `colorScheme` and `setColorScheme` from deps
+    // to prevent re-renders from creating a loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [systemColorScheme]);
 
-  if (hasHydrated) {
-    return colorScheme;
+  if (!hasHydrated) {
+    return {
+      colorScheme: "light",
+      isDarkColorScheme: false,
+      setColorScheme,
+      toggleColorScheme,
+    };
   }
 
-  return "light";
+  return {
+    colorScheme: colorScheme ?? "light",
+    isDarkColorScheme: colorScheme === "dark",
+    setColorScheme,
+    toggleColorScheme,
+  };
 }


### PR DESCRIPTION
## Summary
- sync NativeWind's color scheme with system dark/light mode on web
- avoid update loops when the system color mode changes

## Testing
- `npx expo lint` *(fails: `expo` not found)*