### PR TITLE
Fix profile-update header color theme

### DIFF
--- a/app/(tabs)/profile-update.tsx
+++ b/app/(tabs)/profile-update.tsx
@@ -1,5 +1,7 @@
 import { ThemedView } from "@/components/ThemedView";
 import { Text } from "@/components/ui/text";
+import { useColorScheme as useAppColorScheme } from "@/hooks/useColorScheme";
+import { Colors } from "@/constants/Colors";
 import { useQuery } from "convex-helpers/react/cache";
 import { useMutation } from "convex/react";
 import { Image } from "expo-image";
@@ -15,7 +17,6 @@ import {
   StyleSheet,
   TextInput,
   TouchableOpacity,
-  useColorScheme,
 } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 import { api } from "../../convex/_generated/api";
@@ -35,7 +36,7 @@ export default function ProfileUpdateScreen() {
     useState<ImagePicker.ImagePickerAsset | null>(null);
   const [loading, setLoading] = useState(false);
   const posthog = usePostHog();
-  const colorScheme = useColorScheme();
+  const { colorScheme } = useAppColorScheme();
 
   // Define dynamic colors based on colorScheme
   const textColor = colorScheme === "dark" ? "#fff" : "#000";
@@ -148,10 +149,8 @@ export default function ProfileUpdateScreen() {
     "https://placehold.co/100x100/e0e0e0/a0a0a0?text=%20";
 
   // Adjusted headerStyle to use dynamic background color or be transparent
-  const headerStyle =
-    colorScheme === "dark"
-      ? { backgroundColor: "#1c1c1e" }
-      : { backgroundColor: "#f2f2f7" };
+  const theme = colorScheme ?? "light";
+  const headerStyle = { backgroundColor: Colors[theme].background };
 
   return (
     <ThemedView style={styles.container}>


### PR DESCRIPTION
## Summary
- use app color scheme hook in profile update screen
- set header background using theme colors

## Testing
- `npx expo lint` *(fails: expo unavailable offline)*