### PR TITLE
Add explore feed and assign tasks to users

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,12 +1,21 @@
-import { Authenticated, Unauthenticated, useConvexAuth } from "convex/react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useQuery } from "convex-helpers/react/cache";
+import {
+  Authenticated,
+  Unauthenticated,
+  useConvexAuth,
+  useMutation,
+} from "convex/react";
 import { Redirect, Stack } from "expo-router";
-import React from "react";
+import React, { useEffect } from "react";
 import { ActivityIndicator, View } from "react-native";
 import { api } from "../../convex/_generated/api";
 
+const GUEST_USER_KEY = "soonlist_guest_user_id";
+
 export default function AuthLayout() {
   const { isLoading, isAuthenticated } = useConvexAuth();
+  const transferGuestTasks = useMutation(api.tasks.transferGuestTasks);
 
   // Fetch user data only when authenticated.
   // Pass "skip" to useQuery to prevent it from running if not authenticated.
@@ -14,6 +23,31 @@ export default function AuthLayout() {
     api.users.getCurrentUser,
     isAuthenticated ? {} : "skip",
   );
+
+  // Handle guest task transfer when user becomes authenticated
+  useEffect(() => {
+    const handleGuestTaskTransfer = async () => {
+      if (isAuthenticated && user?.onboarded) {
+        try {
+          const hasGuestTasks = await AsyncStorage.getItem("has_guest_tasks");
+          const guestUserId = await AsyncStorage.getItem(GUEST_USER_KEY);
+
+          if (hasGuestTasks === "true" && guestUserId) {
+            console.log("Transferring guest tasks for user:", guestUserId);
+            const transferredCount = await transferGuestTasks({ guestUserId });
+            console.log(`Transferred ${transferredCount} guest tasks`);
+
+            // Clean up guest data after successful transfer
+            await AsyncStorage.multiRemove(["has_guest_tasks", GUEST_USER_KEY]);
+          }
+        } catch (error) {
+          console.error("Failed to transfer guest tasks:", error);
+        }
+      }
+    };
+
+    handleGuestTaskTransfer();
+  }, [isAuthenticated, user?.onboarded, transferGuestTasks]);
 
   if (isLoading) {
     // This isLoading is from useConvexAuth, indicating Clerk auth state is loading.

--- a/app/(auth)/guest-tasks.tsx
+++ b/app/(auth)/guest-tasks.tsx
@@ -4,16 +4,19 @@ import {
   BottomSheetTextInput,
   BottomSheetView,
 } from "@gorhom/bottom-sheet";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useMutation, usePaginatedQuery } from "convex/react";
-import { useMemo, useRef, useState } from "react";
-import { FlatList, TouchableOpacity, View, useColorScheme } from "react-native";
 import { useRouter } from "expo-router";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { FlatList, TouchableOpacity, View, useColorScheme } from "react-native";
 
 import { TaskItem } from "@/components/TaskItem";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Text } from "@/components/ui/text";
 import { useDebounce } from "@/hooks/useDebounce";
+
+const GUEST_USER_KEY = "soonlist_guest_user_id";
 
 export default function GuestTasks() {
   const router = useRouter();
@@ -24,22 +27,46 @@ export default function GuestTasks() {
     colorScheme === "dark" ? "rgba(255, 255, 255, 0.1)" : "rgba(0, 0, 0, 0.05)";
   const [searchInput, setSearchInput] = useState("");
   const debouncedSearch = useDebounce(searchInput, 300);
+  const [guestUserId, setGuestUserId] = useState<string | null>(null);
+
   const { results, loadMore } = usePaginatedQuery(
-    api.tasks.search,
-    { searchQuery: debouncedSearch },
+    api.tasks.searchGuest,
+    { searchQuery: debouncedSearch, guestUserId: guestUserId || "" },
     { initialNumItems: 20 },
   );
   const [newTaskText, setNewTaskText] = useState("");
   const [hasAddedTask, setHasAddedTask] = useState(false);
-  const createTask = useMutation(api.tasks.createTask);
+  const createGuestTask = useMutation(api.tasks.createGuestTask);
 
   const bottomSheetRef = useRef<BottomSheetModal>(null);
   const snapPoints = useMemo(() => ["50%"], []);
 
+  // Initialize or retrieve guest user ID on component mount
+  useEffect(() => {
+    const initializeGuestUser = async () => {
+      try {
+        let guestId = await AsyncStorage.getItem(GUEST_USER_KEY);
+        if (!guestId) {
+          // Create a unique guest ID using timestamp + random string
+          guestId = `guest_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+          await AsyncStorage.setItem(GUEST_USER_KEY, guestId);
+        }
+        setGuestUserId(guestId);
+      } catch (error) {
+        console.error("Failed to initialize guest user:", error);
+        // Fallback to a session-based ID if AsyncStorage fails
+        const fallbackId = `guest_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+        setGuestUserId(fallbackId);
+      }
+    };
+
+    initializeGuestUser();
+  }, []);
+
   const handleAddTask = async () => {
-    if (newTaskText.trim() === "") return;
+    if (newTaskText.trim() === "" || !guestUserId) return;
     try {
-      await createTask({ text: newTaskText });
+      await createGuestTask({ text: newTaskText, guestUserId });
       setHasAddedTask(true);
       setNewTaskText("");
       bottomSheetRef.current?.dismiss();
@@ -48,11 +75,20 @@ export default function GuestTasks() {
     }
   };
 
+  const handleSignUp = () => {
+    // Store that we have guest tasks to transfer later
+    if (hasAddedTask) {
+      AsyncStorage.setItem("has_guest_tasks", "true");
+    }
+    router.push("/intro");
+  };
+
   return (
     <View className="bg-background flex-1">
       <View className="bg-background flex-1 p-4">
         <View className="bg-background flex-row items-center gap-2 mt-4 mb-4">
           <Text className="text-3xl font-bold">Tasks</Text>
+          <Text className="text-sm text-muted-foreground">(Guest Mode)</Text>
         </View>
 
         <View className="bg-background my-4">
@@ -89,7 +125,7 @@ export default function GuestTasks() {
 
       {hasAddedTask && (
         <Button
-          onPress={() => router.push("/intro")}
+          onPress={handleSignUp}
           className="absolute left-4 right-4 bottom-20"
         >
           <Text>Sign Up to Save Tasks</Text>

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -1,20 +1,50 @@
-import { ScrollView, View } from "react-native";
+import { api } from "@/convex/_generated/api";
+import { usePaginatedQuery } from "convex/react";
+import { useState } from "react";
+import { FlatList, View } from "react-native";
 
+import { TaskItem } from "@/components/TaskItem";
+import { Input } from "@/components/ui/input";
 import { Text } from "@/components/ui/text";
+import { useDebounce } from "@/hooks/useDebounce";
 
 export default function ExploreScreen() {
+  const [searchInput, setSearchInput] = useState("");
+  const debouncedSearch = useDebounce(searchInput, 300);
+  const { results, loadMore } = usePaginatedQuery(
+    api.tasks.searchOthers,
+    { searchQuery: debouncedSearch },
+    { initialNumItems: 20 },
+  );
+
   return (
-    <View className="bg-background flex-1">
-      <ScrollView className="flex-1">
-        <View className="bg-background p-4">
-          <View className="bg-background flex-row gap-2 mt-4 mb-4">
-            <Text className="text-3xl font-bold">Explore</Text>
-          </View>
-          <View className="bg-background mb-4">
-            <Text>This is the explore tab. Add your content here.</Text>
-          </View>
-        </View>
-      </ScrollView>
+    <View className="bg-background flex-1 p-4">
+      <View className="bg-background flex-row gap-2 mt-4 mb-4">
+        <Text className="text-3xl font-bold">Explore</Text>
+      </View>
+
+      <View className="bg-background my-4">
+        <Input
+          className="w-full"
+          placeholder="Search tasks..."
+          value={searchInput}
+          onChangeText={setSearchInput}
+        />
+      </View>
+
+      <FlatList
+        data={results}
+        keyExtractor={(item) => item._id}
+        renderItem={({ item }) => (
+          <TaskItem
+            id={item._id}
+            text={item.text}
+            isCompleted={item.isCompleted}
+          />
+        )}
+        onEndReached={() => loadMore(20)}
+        contentContainerStyle={{ paddingBottom: 80 }}
+      />
     </View>
   );
 }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -18,7 +18,7 @@ export default function HomeScreen() {
   const [searchInput, setSearchInput] = useState("");
   const debouncedSearch = useDebounce(searchInput, 300);
   const { results, loadMore } = usePaginatedQuery(
-    api.tasks.search,
+    api.tasks.searchMine,
     { searchQuery: debouncedSearch },
     { initialNumItems: 20 },
   );

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -6,6 +6,7 @@ export default defineSchema({
     text: v.string(),
     isCompleted: v.boolean(),
     ownerToken: v.optional(v.string()),
+    isGuest: v.optional(v.boolean()),
   })
     .searchIndex("search_text", {
       searchField: "text",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -5,9 +5,12 @@ export default defineSchema({
   tasks: defineTable({
     text: v.string(),
     isCompleted: v.boolean(),
-  }).searchIndex("search_text", {
-    searchField: "text",
-  }),
+    ownerToken: v.optional(v.string()),
+  })
+    .searchIndex("search_text", {
+      searchField: "text",
+    })
+    .index("by_owner", ["ownerToken"]),
 
   users: defineTable({
     firstName: v.optional(v.string()),

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -15,7 +15,12 @@ export const get = query({
 export const createTask = mutation({
   args: { text: v.string() },
   handler: async (ctx, args) => {
-    await ctx.db.insert("tasks", { text: args.text, isCompleted: false });
+    const identity = await ctx.auth.getUserIdentity();
+    await ctx.db.insert("tasks", {
+      text: args.text,
+      isCompleted: false,
+      ownerToken: identity ? identity.tokenIdentifier : undefined,
+    });
   },
 });
 
@@ -32,12 +37,55 @@ export const search = query({
     paginationOpts: paginationOptsValidator,
   },
   handler: async (ctx, { searchQuery, paginationOpts }) => {
-    let q = ctx.db.query("tasks");
+    let q: any = ctx.db.query("tasks");
     if (searchQuery.trim().length > 0) {
       return await q
-        .withSearchIndex("search_text", (q2) => q2.search("text", searchQuery))
+        .withSearchIndex("search_text", (q2: any) => q2.search("text", searchQuery))
         .paginate(paginationOpts);
     }
+    return await q.order("desc").paginate(paginationOpts);
+  },
+});
+
+export const searchMine = query({
+  args: {
+    searchQuery: v.string(),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, { searchQuery, paginationOpts }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      return { page: [], isDone: true, continueCursor: null as unknown as string };
+    }
+
+    let q: any = ctx.db.query("tasks");
+    if (searchQuery.trim().length > 0) {
+      q = q.withSearchIndex("search_text", (q2: any) => q2.search("text", searchQuery));
+    }
+
+    q = q.filter((q2: any) => q2.eq(q2.field("ownerToken"), identity.tokenIdentifier));
+
+    return await q.order("desc").paginate(paginationOpts);
+  },
+});
+
+export const searchOthers = query({
+  args: {
+    searchQuery: v.string(),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, { searchQuery, paginationOpts }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    let q: any = ctx.db.query("tasks");
+
+    if (searchQuery.trim().length > 0) {
+      q = q.withSearchIndex("search_text", (q2: any) => q2.search("text", searchQuery));
+    }
+
+    if (identity) {
+      q = q.filter((q2: any) => q2.neq(q2.field("ownerToken"), identity.tokenIdentifier));
+    }
+
     return await q.order("desc").paginate(paginationOpts);
   },
 });

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -16,11 +16,56 @@ export const createTask = mutation({
   args: { text: v.string() },
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
-    await ctx.db.insert("tasks", {
+
+    const taskId = await ctx.db.insert("tasks", {
       text: args.text,
       isCompleted: false,
-      ownerToken: identity ? identity.tokenIdentifier : undefined,
+      ownerToken: identity?.tokenIdentifier,
+      isGuest: false,
     });
+
+    return taskId;
+  },
+});
+
+export const createGuestTask = mutation({
+  args: { text: v.string(), guestUserId: v.string() },
+  handler: async (ctx, args) => {
+    // Create a task for a guest user using their guest ID
+    const taskId = await ctx.db.insert("tasks", {
+      text: args.text,
+      isCompleted: false,
+      ownerToken: args.guestUserId, // Use guest ID as owner token for now
+      isGuest: true,
+    });
+
+    return taskId;
+  },
+});
+
+export const transferGuestTasks = mutation({
+  args: { guestUserId: v.string() },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Not authenticated");
+    }
+
+    // Find all tasks with the guest user ID
+    const guestTasks = await ctx.db
+      .query("tasks")
+      .filter((q) => q.eq(q.field("ownerToken"), args.guestUserId))
+      .collect();
+
+    // Update each task to be owned by the authenticated user
+    for (const task of guestTasks) {
+      await ctx.db.patch(task._id, {
+        ownerToken: identity.tokenIdentifier,
+        isGuest: false,
+      });
+    }
+
+    return guestTasks.length; // Return number of transferred tasks
   },
 });
 
@@ -40,9 +85,34 @@ export const search = query({
     let q: any = ctx.db.query("tasks");
     if (searchQuery.trim().length > 0) {
       return await q
-        .withSearchIndex("search_text", (q2: any) => q2.search("text", searchQuery))
+        .withSearchIndex("search_text", (q2: any) =>
+          q2.search("text", searchQuery),
+        )
         .paginate(paginationOpts);
     }
+    return await q.order("desc").paginate(paginationOpts);
+  },
+});
+
+export const searchGuest = query({
+  args: {
+    searchQuery: v.string(),
+    guestUserId: v.string(),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, { searchQuery, guestUserId, paginationOpts }) => {
+    let q: any = ctx.db.query("tasks");
+
+    if (searchQuery.trim().length > 0) {
+      q = q.withSearchIndex("search_text", (q2: any) =>
+        q2.search("text", searchQuery),
+      );
+      q = q.filter((q2: any) => q2.eq(q2.field("ownerToken"), guestUserId));
+      return await q.paginate(paginationOpts);
+    }
+
+    q = q.filter((q2: any) => q2.eq(q2.field("ownerToken"), guestUserId));
+
     return await q.order("desc").paginate(paginationOpts);
   },
 });
@@ -55,15 +125,27 @@ export const searchMine = query({
   handler: async (ctx, { searchQuery, paginationOpts }) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
-      return { page: [], isDone: true, continueCursor: null as unknown as string };
+      return {
+        page: [],
+        isDone: true,
+        continueCursor: null as unknown as string,
+      };
     }
 
     let q: any = ctx.db.query("tasks");
     if (searchQuery.trim().length > 0) {
-      q = q.withSearchIndex("search_text", (q2: any) => q2.search("text", searchQuery));
+      q = q.withSearchIndex("search_text", (q2: any) =>
+        q2.search("text", searchQuery),
+      );
+      q = q.filter((q2: any) =>
+        q2.eq(q2.field("ownerToken"), identity.tokenIdentifier),
+      );
+      return await q.paginate(paginationOpts);
     }
 
-    q = q.filter((q2: any) => q2.eq(q2.field("ownerToken"), identity.tokenIdentifier));
+    q = q.filter((q2: any) =>
+      q2.eq(q2.field("ownerToken"), identity.tokenIdentifier),
+    );
 
     return await q.order("desc").paginate(paginationOpts);
   },
@@ -79,12 +161,26 @@ export const searchOthers = query({
     let q: any = ctx.db.query("tasks");
 
     if (searchQuery.trim().length > 0) {
-      q = q.withSearchIndex("search_text", (q2: any) => q2.search("text", searchQuery));
+      q = q.withSearchIndex("search_text", (q2: any) =>
+        q2.search("text", searchQuery),
+      );
+      if (identity) {
+        q = q.filter((q2: any) =>
+          q2.neq(q2.field("ownerToken"), identity.tokenIdentifier),
+        );
+      }
+      // Only show tasks from authenticated users (exclude guest tasks)
+      q = q.filter((q2: any) => q2.neq(q2.field("isGuest"), true));
+      return await q.paginate(paginationOpts);
     }
 
     if (identity) {
-      q = q.filter((q2: any) => q2.neq(q2.field("ownerToken"), identity.tokenIdentifier));
+      q = q.filter((q2: any) =>
+        q2.neq(q2.field("ownerToken"), identity.tokenIdentifier),
+      );
     }
+    // Only show tasks from authenticated users (exclude guest tasks)
+    q = q.filter((q2: any) => q2.neq(q2.field("isGuest"), true));
 
     return await q.order("desc").paginate(paginationOpts);
   },
@@ -98,7 +194,7 @@ export const splitTask = mutation({
       internal.splitTaskWorkflow.splitTaskWorkflow,
       {
         text: args.text,
-      }
+      },
     );
   },
 });


### PR DESCRIPTION
## Summary
- assign tasks to the current user by storing `ownerToken`
- allow filtering for the current user's tasks or others
- show public tasks on the Explore tab

## Testing
- `pnpm lint`
- `pnpm typecheck`
