### PR TITLE
Fix auth hooks to use Convex helpers

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "convex-helpers/react/cache";
 import {
   Authenticated,
   Unauthenticated,
+  AuthLoading,
   useConvexAuth,
   useMutation,
 } from "convex/react";
@@ -49,17 +50,13 @@ export default function AuthLayout() {
     handleGuestTaskTransfer();
   }, [isAuthenticated, user?.onboarded, transferGuestTasks]);
 
-  if (isLoading) {
-    // This isLoading is from useConvexAuth, indicating Clerk auth state is loading.
-    return (
-      <View className="flex-1 justify-center items-center">
-        <ActivityIndicator size="large" />
-      </View>
-    );
-  }
-
   return (
     <>
+      <AuthLoading>
+        <View className="flex-1 justify-center items-center">
+          <ActivityIndicator size="large" />
+        </View>
+      </AuthLoading>
       <Unauthenticated>
         {/* Stack for unauthenticated users */}
         <Stack

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -7,13 +7,13 @@ import { IconSymbol } from "@/components/ui/IconSymbol";
 import TabBarBackground from "@/components/ui/TabBarBackground";
 import { useColorScheme } from "@/hooks/useColorScheme";
 import { NAV_THEME } from "@/lib/constants";
-import { useAuth } from "@clerk/clerk-expo";
+import { useConvexAuth } from "convex/react";
 
 export default function TabLayout() {
   const { colorScheme } = useColorScheme();
-  const { isSignedIn } = useAuth();
+  const { isAuthenticated } = useConvexAuth();
 
-  if (!isSignedIn) {
+  if (!isAuthenticated) {
     return <Redirect href={"/intro"} />;
   }
 


### PR DESCRIPTION
## Summary
- switch tab layout to use `useConvexAuth`
- use `<AuthLoading>` while auth is loading in auth layout

## Testing
- `pnpm lint`
- `pnpm typecheck`
